### PR TITLE
Support Juju 3.4

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -9,6 +9,10 @@ on:
       - "**.md"
       - "**.rst"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   lint-unit:
     uses: canonical/bootstack-actions/.github/workflows/lint-unit.yaml@v2

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -18,7 +18,6 @@ jobs:
         python-version: ["3.8", "3.10"]
     with:
       python-version: ${{ matrix.python-version }}
-      tox-version: "<4"
 
   func:
     uses: canonical/bootstack-actions/.github/workflows/func.yaml@v3
@@ -27,15 +26,14 @@ jobs:
       fail-fast: false
     with:
       command: "make functional"
-      juju-channel: "2.9/stable"
+      juju-channel: "3.4/stable"
       nested-containers: false
       python-version: "3.10"
       timeout-minutes: 120
-      tox-version: "<4"
       action-operator: false
       external-controller: true
       runs-on: "['self-hosted', 'runner-cloudsupport']"
-      juju-controller: soleng-ci-ctrl-29
+      juju-controller: soleng-ci-ctrl-34
       zaza-yaml: "LS0tCm1vZGVsX3NldHRpbmdzOgogIGltYWdlLXN0cmVhbTogcmVsZWFzZWQKcmVnaW9uOiBwcm9kc3RhY2s2CmNsb3VkOiBidWlsZGVyLWNsb3VkLTI5CmNyZWRlbnRpYWw6IGJ1aWxkZXItY2xvdWQtMjktY3JlZAo="
     secrets:
       juju-controllers-yaml: ${{ secrets.JUJU_CONTROLLERS_YAML }}

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -34,7 +34,7 @@ jobs:
       external-controller: true
       runs-on: "['self-hosted', 'runner-cloudsupport']"
       juju-controller: soleng-ci-ctrl-34
-      zaza-yaml: "LS0tCm1vZGVsX3NldHRpbmdzOgogIGltYWdlLXN0cmVhbTogcmVsZWFzZWQKcmVnaW9uOiBwcm9kc3RhY2s2CmNsb3VkOiBidWlsZGVyLWNsb3VkLTI5CmNyZWRlbnRpYWw6IGJ1aWxkZXItY2xvdWQtMjktY3JlZAo="
+      zaza-yaml: "LS0tCm1vZGVsX3NldHRpbmdzOgogIGltYWdlLXN0cmVhbTogcmVsZWFzZWQKcmVnaW9uOiBwcm9kc3RhY2s2CmNsb3VkOiBidWlsZGVyLWNsb3VkCmNyZWRlbnRpYWw6IGJ1aWxkZXItY2xvdWQtY3JlZAoK"
     secrets:
       juju-controllers-yaml: ${{ secrets.JUJU_CONTROLLERS_YAML }}
       juju-accounts-yaml: ${{ secrets.JUJU_ACCOUNTS_YAML }}

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -24,9 +24,13 @@ jobs:
     needs: lint-unit
     strategy:
       fail-fast: false
+      matrix:
+        command: ["TEST_JUJU3=1 make functional"]  # TEST_JUJU3 needed due https://github.com/openstack-charmers/zaza/blob/b22c2eed4c322f1dfc14ffb2d31e0dd18c911a40/setup.py#L47 to support Juju3+
+        juju-channel: ["3.4/stable"]
+        
     with:
-      command: "TEST_JUJU3=1 make functional"  # TEST_JUJU3 needed due https://github.com/openstack-charmers/zaza/blob/b22c2eed4c322f1dfc14ffb2d31e0dd18c911a40/setup.py#L47 to support Juju3+
-      juju-channel: "3.4/stable"
+      command: ${{ matrix.command }}
+      juju-channel: ${{ matrix.juju-channel }}
       nested-containers: false
       python-version: "3.10"
       timeout-minutes: 120

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -25,7 +25,7 @@ jobs:
     strategy:
       fail-fast: false
     with:
-      command: "make functional"
+      command: "TEST_JUJU3=1 make functional"  # TEST_JUJU3 needed due https://github.com/openstack-charmers/zaza/blob/b22c2eed4c322f1dfc14ffb2d31e0dd18c911a40/setup.py#L47 to support Juju3+
       juju-channel: "3.4/stable"
       nested-containers: false
       python-version: "3.10"

--- a/tests/functional/requirements.txt
+++ b/tests/functional/requirements.txt
@@ -1,4 +1,4 @@
-git+https://github.com/rgildein/zaza.git@chore/no-ref/fix-action-object#egg=zaza
+git+https://github.com/openstack-charmers/zaza.git@master#egg=zaza
 git+https://github.com/openstack-charmers/zaza-openstack-tests.git#egg=zaza.openstack
 flake8
 tenacity

--- a/tests/functional/requirements.txt
+++ b/tests/functional/requirements.txt
@@ -1,4 +1,4 @@
-git+https://github.com/openstack-charmers/zaza.git#egg=zaza
+git+https://github.com/rgildein/zaza.git@chore/no-ref/fix-action-object#egg=zaza
 git+https://github.com/openstack-charmers/zaza-openstack-tests.git#egg=zaza.openstack
 flake8
 tenacity

--- a/tests/functional/tests/bundles/base-yoga-ovn.yaml
+++ b/tests/functional/tests/bundles/base-yoga-ovn.yaml
@@ -21,7 +21,6 @@ machines:
   '10':
   '11':
   '12':
-    series: bionic
   '13':
     constraints: mem=3072M
   '14':
@@ -30,11 +29,9 @@ machines:
     constraints: mem=3072M
 
 applications:
-  nagios:
-    charm: ch:nagios
-    channel: latest/edge
+  cos-proxy:  # using cos-proxy instead of nagios, since we are testing only relation joined
+    charm: cos-proxy
     num_units: 1
-    series: bionic
     to:
       - '12'
   nrpe:
@@ -234,7 +231,7 @@ relations:
     - 'nrpe:nrpe-external-master'
 
   - - 'nrpe:monitors'
-    - 'nagios:monitors'
+    - 'cos-proxy:monitors'
   - - 'vault:shared-db'
     - 'vault-mysql-router:shared-db'
   - - 'vault-mysql-router:db-router'

--- a/tests/functional/tests/bundles/base-yoga-ovn.yaml
+++ b/tests/functional/tests/bundles/base-yoga-ovn.yaml
@@ -41,6 +41,7 @@ applications:
     charm: ch:nrpe
     channel: latest/edge
   cloudsupport:
+    charm: cloudsupport
     num_units: 1
     to:
       - '11'

--- a/tests/functional/tests/bundles/base-yoga.yaml
+++ b/tests/functional/tests/bundles/base-yoga.yaml
@@ -36,6 +36,7 @@ applications:
     charm: ch:nrpe
     channel: latest/edge
   cloudsupport:
+    charm: cloudsupport
     num_units: 1
     to:
       - '11'

--- a/tests/functional/tests/bundles/base-yoga.yaml
+++ b/tests/functional/tests/bundles/base-yoga.yaml
@@ -21,15 +21,12 @@ machines:
     constraints: mem=4096M cores=4
   '11':
   '12':
-    series: bionic
   '13':
 
 applications:
-  nagios:
-    charm: ch:nagios
-    channel: latest/edge
+  cos-proxy:  # using cos-proxy instead of nagios, since we are testing only relation joined
+    charm: cos-proxy
     num_units: 1
-    series: bionic
     to:
       - '12'
   nrpe:
@@ -245,7 +242,7 @@ relations:
     - 'nrpe:nrpe-external-master'
 
   - - 'nrpe:monitors'
-    - 'nagios:monitors'
+    - 'cos-proxy:monitors'
   - - 'vault:shared-db'
     - 'vault-mysql-router:shared-db'
   - - 'vault-mysql-router:db-router'

--- a/tests/functional/tests/bundles/overlays/local-charm-overlay.yaml.j2
+++ b/tests/functional/tests/bundles/overlays/local-charm-overlay.yaml.j2
@@ -1,3 +1,3 @@
 applications:
-  cloudsupport:
+  {{ charm_name }}:
     charm: "{{ CHARM_LOCATION }}/{{ charm_name }}.charm"

--- a/tests/functional/tests/modules/test_cloudsupport.py
+++ b/tests/functional/tests/modules/test_cloudsupport.py
@@ -134,7 +134,7 @@ class CloudSupportTests(CloudSupportBaseTest):
             vnfspecs=False,
         )
         self.assertEqual(result.status, "completed")
-        self.assertEqual(result.results.get("Code"), "0")
+        self.assertEqual(result.results.get("return-code"), 0)
         self.assertEqual(result.results.get("create-results"), "success")
         details = result.results.get("create-details").replace("'", '"')
         _, server_id, _ = json.loads(details)[0]

--- a/tests/functional/tests/tests.yaml
+++ b/tests/functional/tests/tests.yaml
@@ -30,3 +30,6 @@ target_deploy_status:
   ovn-chassis-octavia:
     workload-status: waiting
     workload-status-message-prefix: "'certificates' awaiting server certificate data"
+  cos-proxy:
+    workload-status: blocked
+    workload-status-message-prefix: "Missing one of (Prometheus|target|nrpe) relation(s)"

--- a/tox.ini
+++ b/tox.ini
@@ -81,5 +81,5 @@ commands = pytest -sv \
 
 [testenv:func]
 changedir = {toxinidir}/tests/functional
-commands = functest-run-suite --keep-faulty-model {posargs}
+commands = functest-run-suite {posargs:--keep-faulty-model}
 deps = -r{toxinidir}/tests/functional/requirements.txt

--- a/tox.ini
+++ b/tox.ini
@@ -27,6 +27,7 @@ passenv =
   SNAP_HTTP_PROXY
   SNAP_HTTPS_PROXY
   OS_*
+  TEST_*
 
 [testenv:lint]
 commands =


### PR DESCRIPTION
Switching CI run with Juju 3.4 on Juju 3.4 controller. To be able to support Juju 3.4, we need to get rid of nagios, however one test depend on it. I decide to switch to cos-proxy, since only think we need is to be able to create monitors relation.

Add workflow concurrency to avoid running multiple workflows on a single PR. Like this if new commit arrived the previous run will be canceled by new run.

~~Blocked until [#655](https://github.com/openstack-charmers/zaza/pull/655) is merged.~~