### PR TITLE
test: update workload status message for cos proxy

### DIFF
--- a/tests/functional/tests/tests.yaml
+++ b/tests/functional/tests/tests.yaml
@@ -32,4 +32,4 @@ target_deploy_status:
     workload-status-message-prefix: "'certificates' awaiting server certificate data"
   cos-proxy:
     workload-status: blocked
-    workload-status-message-prefix: "Missing one of (Prometheus|target|nrpe) relation(s)"
+    workload-status-message-prefix: "Missing one of (Prometheus|target|nrpe|grafana-agent) relation(s)"


### PR DESCRIPTION
The workload status for cos proxy has been updated to `Missing one of (Prometheus|target|nrpe|grafana-agent) relation(s)` in newer revision of cos-proxy. See workflow run for example: https://github.com/canonical/charm-cloudsupport/actions/runs/9263270067/job/25585050653#step:17:1003