### PR TITLE
Fix functional tests on juju3

### DIFF
--- a/tests/functional/tests/modules/setup.py
+++ b/tests/functional/tests/modules/setup.py
@@ -40,8 +40,10 @@ def model_config():
         f_cloudinit.write(ud)
         # move file pointer to 0 so it can be read again without closing
         f_cloudinit.seek(0)
-        logging.debug("Running juju model-config {}".format(f_cloudinit.name))
-        subprocess.run("juju model-config {}".format(f_cloudinit.name), shell=True)
+        logging.debug("Running juju model-config --file {}".format(f_cloudinit.name))
+        subprocess.run(
+            "juju model-config --file {}".format(f_cloudinit.name), shell=True
+        )
 
 
 # Retry upto 3 minutes because sometimes vault is not ready,


### PR DESCRIPTION
`juju model-config` had breaking changes for reading from a yaml file between 2.9 and 3.4 - note the new `--file` argument:

juju 2.9:
```
$ juju_29 model-config --help
...
Set the model config key value pairs defined in a file:
    juju model-config path/to/file.yaml
...
```

juju 3.4
```
$ juju_34 model-config --help
...
Set the model config to key=value pairs defined in a file:

    juju model-config --file path/to/file.yaml
...
```

Fixes: #22