### PR TITLE
Update requirements for noble

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
-charmhelpers~=1.1.0
-ops~=1.3.0
+charmhelpers @ git+https://github.com/juju/charm-helpers@master
 click
-fabric~=2.6.0
+fabric
+ops
 python-openstackclient
-PyYAML~=6.0
+PyYAML


### PR DESCRIPTION
This commit unpins requirements, allowing for unit tests to pass on
Ubuntu noble (Python 3.12)
