### PR TITLE
Update requirements for noble

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -28,6 +28,8 @@ parts:
       - rustc
       - cargo
       - libssl-dev
+      # Needed by charmhelpers (master branch)
+      - git
     charm-binary-python-packages:
       # Updated versions needed for working nicely with
       # jinja2/markupsafe

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -15,10 +15,6 @@ bases:
           channel: "20.04"
           architectures:
               - amd64
-        - name: ubuntu
-          channel: "18.04"
-          architectures:
-              - amd64
 parts:
   charm:
     source: .

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
-charmhelpers~=1.1.0
-ops~=1.3.0
+charmhelpers @ git+https://github.com/juju/charm-helpers@master
 click
-fabric~=2.6.0
+fabric
+ops
 python-openstackclient
-PyYAML~=6.0
+PyYAML


### PR DESCRIPTION
This commit unpins requirements, allowing for unit tests to pass on
Ubuntu noble (Python 3.12)

Partial-fix: #16 
