### PR TITLE
Revert "Pin charmcraft to 2.x while we work on converting to the 3.x format (#33)"

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -22,7 +22,6 @@ jobs:
       - name: Upload charm to charmhub
         uses: canonical/charming-actions/upload-charm@2.4.0
         with:
-          charmcraft-channel: "2.x/stable"
           credentials: "${{ secrets.CHARMHUB_TOKEN }}"
           github-token: "${{ secrets.GITHUB_TOKEN }}"
           channel: "latest/edge"


### PR DESCRIPTION
bootstack-actions don't support setting the charmcraft channel so we
need to convert to the new format now

This reverts commit cacd744a564b9bc6f9963cab4c299a84178ac827.
