### PR TITLE
Add a debug switch to tell zaza to keep the model around

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -20,9 +20,6 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
-env:
-  # TEST_JUJU3 needed due https://github.com/openstack-charmers/zaza/blob/b22c2eed4c322f1dfc14ffb2d31e0dd18c911a40/setup.py#L47 to support Juju3+
-  func_cmd: "TEST_JUJU3=1 make functional ${{ github.event.inputs.debug_enabled && '--keep-faulty-model' }}"
 
 jobs:
   lint-unit:
@@ -37,10 +34,13 @@ jobs:
   func:
     uses: canonical/bootstack-actions/.github/workflows/func.yaml@v3
     needs: lint-unit
+    env:
+      # TEST_JUJU3 needed due https://github.com/openstack-charmers/zaza/blob/b22c2eed4c322f1dfc14ffb2d31e0dd18c911a40/setup.py#L47 to support Juju3+
+      cmd: "TEST_JUJU3=1 make functional ${{ github.event.inputs.debug_enabled && '--keep-faulty-model' }}"
     strategy:
       fail-fast: false
       matrix:
-        command: ${{ env.func_command }}
+        command: $cmd
         juju-channel: ["3.4/stable"]
         
     with:

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -22,7 +22,7 @@ concurrency:
 
 env:
   # TEST_JUJU3 needed due https://github.com/openstack-charmers/zaza/blob/b22c2eed4c322f1dfc14ffb2d31e0dd18c911a40/setup.py#L47 to support Juju3+
-  func_cmd: TEST_JUJU3=1 make functional ${{ github.event.inputs.debug_enabled && "--keep-faulty-model" }}
+  func_cmd: "TEST_JUJU3=1 make functional ${{ github.event.inputs.debug_enabled && "--keep-faulty-model" }}"
 
 jobs:
   lint-unit:

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -22,7 +22,7 @@ concurrency:
 
 env:
   # TEST_JUJU3 needed due https://github.com/openstack-charmers/zaza/blob/b22c2eed4c322f1dfc14ffb2d31e0dd18c911a40/setup.py#L47 to support Juju3+
-  func_cmd: "TEST_JUJU3=1 make functional ${{ github.event.inputs.debug_enabled && "--keep-faulty-model" }}"
+  func_cmd: "TEST_JUJU3=1 make functional ${{ github.event.inputs.debug_enabled && '--keep-faulty-model' }}"
 
 jobs:
   lint-unit:

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -36,6 +36,8 @@ jobs:
     needs: lint-unit
     with:
       # TEST_JUJU3 needed due https://github.com/openstack-charmers/zaza/blob/b22c2eed4c322f1dfc14ffb2d31e0dd18c911a40/setup.py#L47 to support Juju3+
+      # Don't tear down the OpenStack model if tests fail and --keep-faulty-model is
+      # specified - this allows for interactive debugging of failed runs
       command: "TEST_JUJU3=1 make functional ${{ github.event.inputs.debug_enabled && '--keep-faulty-model' }}"
       juju-channel: "3.4/stable"
       nested-containers: false

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -34,18 +34,10 @@ jobs:
   func:
     uses: canonical/bootstack-actions/.github/workflows/func.yaml@v3
     needs: lint-unit
-    env:
-      # TEST_JUJU3 needed due https://github.com/openstack-charmers/zaza/blob/b22c2eed4c322f1dfc14ffb2d31e0dd18c911a40/setup.py#L47 to support Juju3+
-      cmd: "TEST_JUJU3=1 make functional ${{ github.event.inputs.debug_enabled && '--keep-faulty-model' }}"
-    strategy:
-      fail-fast: false
-      matrix:
-        command: $cmd
-        juju-channel: ["3.4/stable"]
-        
     with:
-      command: ${{ matrix.command }}
-      juju-channel: ${{ matrix.juju-channel }}
+      # TEST_JUJU3 needed due https://github.com/openstack-charmers/zaza/blob/b22c2eed4c322f1dfc14ffb2d31e0dd18c911a40/setup.py#L47 to support Juju3+
+      command: "TEST_JUJU3=1 make functional ${{ github.event.inputs.debug_enabled && '--keep-faulty-model' }}"
+      juju-channel: ["3.4/stable"]
       nested-containers: false
       python-version: "3.10"
       timeout-minutes: 120

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -2,6 +2,12 @@ name: Check workflow running linter, unit and functional tests
 
 on:
   workflow_dispatch:
+    inputs:
+      debug_enabled:
+        description: 'Avoid model destruction to aid debugging failed runs'
+        required: false
+        default: false
+        type: boolean
   workflow_call:
   pull_request:
     types: [opened, synchronize, reopened]
@@ -13,6 +19,10 @@ on:
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
+
+env:
+  # TEST_JUJU3 needed due https://github.com/openstack-charmers/zaza/blob/b22c2eed4c322f1dfc14ffb2d31e0dd18c911a40/setup.py#L47 to support Juju3+
+  func_cmd: TEST_JUJU3=1 make functional ${{ github.event.inputs.debug_enabled && "--keep-faulty-model" }}
 
 jobs:
   lint-unit:
@@ -30,7 +40,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        command: ["TEST_JUJU3=1 make functional"]  # TEST_JUJU3 needed due https://github.com/openstack-charmers/zaza/blob/b22c2eed4c322f1dfc14ffb2d31e0dd18c911a40/setup.py#L47 to support Juju3+
+        command: ${{ env.func_command }}
         juju-channel: ["3.4/stable"]
         
     with:

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       debug_enabled:
-        description: 'Avoid model destruction to aid debugging failed runs'
+        description: 'Skip model cleanup'
         required: false
         default: false
         type: boolean

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -37,7 +37,7 @@ jobs:
     with:
       # TEST_JUJU3 needed due https://github.com/openstack-charmers/zaza/blob/b22c2eed4c322f1dfc14ffb2d31e0dd18c911a40/setup.py#L47 to support Juju3+
       command: "TEST_JUJU3=1 make functional ${{ github.event.inputs.debug_enabled && '--keep-faulty-model' }}"
-      juju-channel: ["3.4/stable"]
+      juju-channel: "3.4/stable"
       nested-containers: false
       python-version: "3.10"
       timeout-minutes: 120


### PR DESCRIPTION
Zaza has a switch --keep-faulty-model that prevents the destruction of a
faulty model, to allow for further troubleshooting. This commit adds a
workflow switch to invoke this functionality from the CI.
